### PR TITLE
[DNM] fix: add match up test of indexes and rangeKeys.

### DIFF
--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -5,13 +5,19 @@ const models = require('../../').models;
 
 describe('model commmons', () => {
     const modelsToCheck = [
-        'event',
-        'pipeline',
         'build',
-        'job',
-        'user',
+        'collection',
         'command',
-        'commandTag'
+        'commandTag',
+        'event',
+        'job',
+        'pipeline',
+        'secret',
+        'template',
+        'templateTag',
+        'token',
+        'trigger',
+        'user'
     ];
 
     it('selected models have tableName defined', () => {
@@ -30,6 +36,19 @@ describe('model commmons', () => {
         modelsToCheck.forEach((model) => {
             assert.isArray(models[model].keys);
             assert.isArray(models[model].allKeys);
+        });
+    });
+
+    // See https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L311
+    it('selected models have same lenght of indexes and rangeKeys.', () => {
+        modelsToCheck.forEach((model) => {
+            if (Object.prototype.hasOwnProperty.call(models[model], 'rangeKeys')) {
+                assert.strictEqual(
+                    models[model].indexes.length,
+                    models[model].rangeKeys.length,
+                    `${model} model: Each range key must matches up with ` +
+                    'an element in the indexes property.');
+            }
         });
     });
 

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -40,7 +40,7 @@ describe('model commmons', () => {
     });
 
     // See https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L311
-    it('selected models have same lenght of indexes and rangeKeys.', () => {
+    it('selected models have same length of indexes and rangeKeys.', () => {
         modelsToCheck.forEach((model) => {
             if (Object.prototype.hasOwnProperty.call(models[model], 'rangeKeys')) {
                 assert.strictEqual(


### PR DESCRIPTION
将来の新規モデル追加に備えて、indexes と rangeKeys の要素数をチェックするテストを追加してみました。
本家にPRする前に、ご意見をいただけるとありがたいです。